### PR TITLE
fix: repeated track not scrobbled

### DIFF
--- a/sources/Scrobbler.x
+++ b/sources/Scrobbler.x
@@ -21,7 +21,7 @@ static BOOL isPlaying = NO;
 		NSString *localID = [item localID];
 
 
-		if ((!currentSongReplayed && currentSongLocalID == localID && mediaTime < 1) && !isPlaying) {
+		if ((!currentSongReplayed && currentSongLocalID == localID && mediaTime < 1) && isPlaying) {
 			currentSongReplayed = YES;
 		}
 


### PR DESCRIPTION
Repeated track is not scrobbled. I suppose `!isPlaying` condition isn't reachable inside poll method, preventing currentSongReplayed from changing its value. Changing it to `isPlaying` like other if-lines fixes the issue.